### PR TITLE
fix(cognito): use PKCE for web

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -41,6 +41,7 @@ export const environment: Environment = {
     logoutUrl: '',
     iosWebView: 'private',
     logLevel: 'DEBUG',
+    webAuthFlow: 'PKCE',
   },
   okta: {
     authConfig: 'general',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -45,6 +45,7 @@ export const environment: Environment = {
     logoutUrl: '',
     iosWebView: 'private',
     logLevel: 'DEBUG',
+    webAuthFlow: 'PKCE',
   },
   okta: {
     authConfig: 'general',


### PR DESCRIPTION
When using implicit flow, Cognito will produce a CORS error on refresh.
This is circumvented by using PKCE on web.